### PR TITLE
Added exception handler in lines 236-237 in common/utilities.py

### DIFF
--- a/common/utilities.py
+++ b/common/utilities.py
@@ -233,7 +233,10 @@ class WriteChargesTask(FiretaskBase):
         with open(os.path.join(job_info_array[-1]['launch_dir'], 'POSCAR'), 'rt') as f:
             poscar_lines = f.readlines()
         elem_list = poscar_lines[0].split()
-        num_ions = [int(item) for item in poscar_lines[5].split()]
+        try:
+            num_ions = [int(item) for item in poscar_lines[5].split()]
+        except ValueError:
+            num_ions = [int(item) for item in poscar_lines[6].split()]
 
         dummy_index = 0
         for elem, amount in zip(elem_list, num_ions):


### PR DESCRIPTION
There was a ValueError: invalid literal for int() with base 10 in write_charges task while executing the command: num_ions = [int(item) for item in poscar_lines[5].split()]. I have added exception handler with additional line num_ions = [int(item) for item in poscar_lines[6].split()] and this problem was fixed.